### PR TITLE
Retain newlines in usage string when called with `--help` command lin…

### DIFF
--- a/src/ib-action.sh
+++ b/src/ib-action.sh
@@ -204,7 +204,7 @@ ib-action() {
 
   while [[ "$#" > 0 ]]; do
     case ${1:-""} in
-      -h|--help) echo $IB_USAGE; exit; break;;
+      -h|--help) echo "$IB_USAGE"; exit; break;;
       --version)
         echo "$(basename ${IB_SCRIPT_NAME%.*}) v$IB_SCRIPT_VERSION"
         exit 0


### PR DESCRIPTION
I downloaded the latest version of the `idempotent-bash.sh` and as I tried to verify that it works by executing the script with `--help` argument, I noticed that the usage string output had lost all of the newlines.

This PR simply adds double quotes around the `$IB_USAGE` variable in echo, so that all the newlines would be rendered properly.